### PR TITLE
Implement sys_getcwd

### DIFF
--- a/kernel/syscalls/getcwd.c
+++ b/kernel/syscalls/getcwd.c
@@ -2,6 +2,7 @@
  * fiwix/kernel/syscalls/getcwd.c
  *
  * Copyright 2018, Jordi Sanfeliu. All rights reserved.
+ * Copyright 2022, Alwin Berger. All rights reserved.
  * Distributed under the terms of the Fiwix License.
  */
 
@@ -27,60 +28,37 @@ int sys_getcwd(char *buf, __size_t size)
 	if((errno = check_user_area(VERIFY_WRITE, buf, size))) {
 		return errno;
 	}
-	/* Psedocode:
-	 * dir <- current->pwd
-	 * if dir == /
-	 *	return "/"
-	 * cwd <- ""
-	 * while dir != /
-	 * 	p <- lookup(..)
-	 *	open(p)
-	 *	dirent <- read(p)
-	 *	for d in dirent
-	 *		if d == dir
-	 *			cwd <- '/' + d.name + cwd
-	 *			dir <- d
-	 *			break
-	 * return cwd
-	 */
-	 if (size==0 || buf==NULL) {    /* buffer self allocation not supported */
-		 return -EINVAL;
-	 }
-	 if (size<2) { /* the shortest path is "/"" */
-		 return -ERANGE;
-	 }
-	struct dirent* dirent_buf;
-	struct dirent* d_ptr;
-	struct inode* cur = current->pwd;
-	struct inode* up = cur;
-	struct inode* root;
-	struct inode* tmp_ino = NULL;
-	int tmp_fd;
-	int bytes_read;
-	int done = 0;
-	__size_t marker = size-2;	/* Reserve '\0' at the end */
-	__size_t namelength;
-	buf[size-1] = 0;
-	char save;
-	__size_t x;
-	if((errno = namei("/",&root,0,FOLLOW_LINKS))) {
-		return errno;
+	/* Buffer self-allocation not supported. */
+	if (size==0 || buf==NULL) {
+		return -EINVAL;
 	}
-	if (cur == root) {
-		/* This case needs special handling, otherwise the loop skips over root */
+	/* The shortest possible path is "/". */
+	if (size<2) {
+		return -ERANGE;
+	}
+	struct dirent *dirent_buf;
+	struct dirent *d_ptr;
+	struct inode *cur = current->pwd;
+	struct inode *up = cur;
+	struct inode *tmp_ino = NULL;
+	int tmp_fd, done;
+	int namelength, bytes_read;
+	__size_t marker = size-2;	/* Reserve '\0' at the end. */
+	buf[size-1] = 0;
+	__size_t x;
+
+	if(cur == current->root) {
+		/* This case needs special handling, otherwise the loop skips over root. */
 		buf[0]='/';
 		buf[1]='\0';
-		iput(root);
 		return (unsigned int)buf;
 	}
 	if(!(dirent_buf = (void *)kmalloc())) {
-		iput(root);
 		return -ENOMEM;
 	}
 
 	do {
-		if((errno = parse_namei("..",cur,&up,0,FOLLOW_LINKS))) {
-			iput(root);
+		if((errno = parse_namei("..", cur, &up, 0, FOLLOW_LINKS))) {
 			if (cur != current->pwd) {
 				iput(cur);
 			}
@@ -88,7 +66,6 @@ int sys_getcwd(char *buf, __size_t size)
 			return errno;
 		}
 		if((tmp_fd = get_new_fd(up)) < 0) {
-			iput(root);
 			iput(up);
 			if (cur != current->pwd) {
 				iput(cur);
@@ -97,12 +74,10 @@ int sys_getcwd(char *buf, __size_t size)
 			return tmp_fd;
 		}
 		do {
-			done=0;
-			bytes_read = up->fsop->readdir(up, &fd_table[tmp_fd],
-					dirent_buf, PAGE_SIZE);
+			done = 0;
+			bytes_read = up->fsop->readdir(up, &fd_table[tmp_fd], dirent_buf, PAGE_SIZE);
 			if (bytes_read < 0) {
 				release_fd(tmp_fd);
-				iput(root);
 				iput(up);
 				if (cur != current->pwd) {
 					iput(cur);
@@ -112,88 +87,57 @@ int sys_getcwd(char *buf, __size_t size)
 			}
 			d_ptr = dirent_buf;
 			while((void *) d_ptr < ((void *) dirent_buf + bytes_read)) {
-				if(up->dev==cur->dev) {
-					if(d_ptr->d_ino==cur->inode) {
-						if(d_ptr->d_ino == cur->inode) {
-							namelength = strlen(d_ptr->d_name);
-							if (marker < namelength+1) {
-								release_fd(tmp_fd);
-								iput(root);
-								iput(up);
-								if (cur != current->pwd) {
-									iput(cur);
-								}
-								kfree((unsigned int)dirent_buf);
-								return -ERANGE;
-							}
-							marker -= namelength+1;	/* +1 for the leading '/' */
-							save=buf[marker+namelength+1];
-							strncpy(buf+marker+1, d_ptr->d_name, namelength);
-							buf[marker] = '/';
-							buf[marker+namelength+1] = save; /* strncp overrides '/' or '\0' */
-							done=1;
-							break;
-						}
-					}
+				if((errno = parse_namei(d_ptr->d_name, up, &tmp_ino, 0, FOLLOW_LINKS))) {
+					/* Keep going if sibling dirents fail. */
+					break;
 				}
-				else if (strcmp(".",d_ptr->d_name) != 0 && strcmp("..",d_ptr->d_name) != 0)
-				{	/* Need to deal with mounts */
-					if((errno = parse_namei(d_ptr->d_name,up,&tmp_ino,0,FOLLOW_LINKS))) {
-						break;	/* Keep going if sibling dirents fail */
-					}
-					if(tmp_ino->inode==cur->inode) {
+				if(tmp_ino->inode == cur->inode) {
+					if(strcmp("..", d_ptr->d_name)) {
 						namelength = strlen(d_ptr->d_name);
 						if (marker < namelength+1) {
 							release_fd(tmp_fd);
-							iput(root);
 							iput(up);
-							iput(tmp_ino);
 							if (cur != current->pwd) {
 								iput(cur);
 							}
 							kfree((unsigned int)dirent_buf);
 							return -ERANGE;
 						}
-						marker -= namelength+1;	/* +1 for the leading '/' */
-						save=buf[marker+namelength+1];
-						strncpy(buf+marker+1, d_ptr->d_name, namelength);
-						buf[marker] = '/';
-						buf[marker+namelength+1] = save; /* strncp overrides '/' or '\0' */
-						done=1;
+						while(--namelength >= 0) {
+							buf[marker--] = d_ptr->d_name[namelength];
+						}
+						buf[marker--] = '/';
 						iput(tmp_ino);
+						done = 1;
 						break;
 					}
-					iput(tmp_ino);
 				}
-				d_ptr = (struct dirent *) ((void *)d_ptr+d_ptr->d_reclen);
+				d_ptr = (struct dirent *) ((void *)d_ptr + d_ptr->d_reclen);
+				iput(tmp_ino);
 			}
 		} while(bytes_read!=0 && !done);
 
-
 		release_fd(tmp_fd);
-		if (!done) {   /* parent dir was fully read, child still not found */
-			iput(root);
+		if(!done) {
+			/* Parent dir was fully read, child still not found. */
 			iput(up);
 			if (cur != current->pwd) {
 				iput(cur);
 			}
 			kfree((unsigned int)dirent_buf);
-			if (errno) {
-				return errno;		/* parse_namei failed on the right dirent */
-			} else {
-				return -ENOENT;
-			}
+			return -ENOENT;
 		}
 		if (cur != current->pwd) {
 			iput(cur);
 		}
 		cur = up;
-	} while(cur != root);
+	} while(cur != current->root);
+
 	kfree((unsigned int)dirent_buf);
-	iput(root); /* cur == up == root */
-	/* Move the String to the start of the buffer */
-	for ( x = marker; x < size; x++) {
-		buf[x-marker]=buf[x];
+	iput(cur);
+	/* Move the String to the start of the buffer. */
+	for (x = ++marker; x < size; x++) {
+		buf[x-marker] = buf[x];
 	}
 	return (unsigned int)buf;
 }

--- a/kernel/syscalls/getcwd.c
+++ b/kernel/syscalls/getcwd.c
@@ -8,6 +8,8 @@
 #include <fiwix/types.h>
 #include <fiwix/fs.h>
 #include <fiwix/errno.h>
+#include <fiwix/string.h>
+#include <fiwix/mm.h>
 
 #ifdef __DEBUG__
 #include <fiwix/stdio.h>
@@ -25,5 +27,131 @@ int sys_getcwd(char *buf, __size_t size)
 	if((errno = check_user_area(VERIFY_WRITE, buf, size))) {
 		return errno;
 	}
-	return -ENOSYS;
+	/* Psedocode:
+	 * dir <- current->pwd
+	 * if dir == /
+	 *	return "/"
+	 * cwd <- ""
+	 * while dir != /
+	 * 	p <- lookup(..)
+	 *	open(p)
+	 *	dirent <- read(p)
+	 *	for d in dirent
+	 *		if d == dir
+	 *			cwd <- '/' + d.name + cwd
+	 *			dir <- d
+	 *			break
+	 * return cwd
+	 */
+	 if (size==0 || buf==NULL) {    /* buffer self allocation not supported */
+		 return -EINVAL;
+	 }
+	 if (size<2) { /* the shortest path is "/"" */
+		 return -ERANGE;
+	 }
+	struct dirent* dirent_buf;
+	struct dirent* d_ptr;
+	struct inode* cur = current->pwd;
+	struct inode* up = cur;
+	struct inode* root;
+	int tmp_fd;
+	int bytes_read;
+	__size_t marker = size-2;	/* Reserve '\0' at the end */
+	__size_t namelength;
+	buf[size-1] = 0;
+	char save;
+	__size_t x;
+	if((errno = namei("/",&root,0,FOLLOW_LINKS))) {
+		return errno;
+	}
+	if (cur == root) {
+		/* This case needs special handling, otherwise the loop skips over root */
+		buf[0]='/';
+		buf[1]='\0';
+		iput(root);
+		return (unsigned int)buf;
+	}
+	if(!(dirent_buf = (void *)kmalloc())) {
+		iput(root);
+		return -ENOMEM;
+	}
+
+	while(cur != root) {
+		if((errno = parse_namei("..",cur,&up,0,FOLLOW_LINKS))) {
+			iput(root);
+			if (cur != current->pwd) {
+				iput(cur);
+			}
+			kfree((unsigned int)dirent_buf);
+			return errno;
+		}
+		if((tmp_fd = get_new_fd(up)) < 0) {
+			iput(root);
+			iput(up);
+			if (cur != current->pwd) {
+				iput(cur);
+			}
+			kfree((unsigned int)dirent_buf);
+			return tmp_fd;
+		}
+		do {
+			bytes_read = up->fsop->readdir(up, &fd_table[tmp_fd],
+					dirent_buf, PAGE_SIZE);
+			if (bytes_read < 0) {
+				release_fd(tmp_fd);
+				iput(root);
+				iput(up);
+				if (cur != current->pwd) {
+					iput(cur);
+				}
+				kfree((unsigned int)dirent_buf);
+				return bytes_read;
+			}
+			d_ptr = dirent_buf;
+			while((void *) d_ptr < ((void *) dirent_buf + bytes_read)) {
+				if(d_ptr->d_ino == cur->inode) {
+					namelength = strlen(d_ptr->d_name);
+					if (marker < namelength+1) {
+						release_fd(tmp_fd);
+						iput(root);
+						iput(up);
+						if (cur != current->pwd) {
+							iput(cur);
+						}
+						kfree((unsigned int)dirent_buf);
+						return -ERANGE;
+					}
+					marker -= namelength+1;	/* +1 for the leading '/' */
+					save=buf[marker+namelength+1];
+					strncpy(buf+marker+1, d_ptr->d_name, namelength);
+					buf[marker] = '/';
+					buf[marker+namelength+1] = save; /* strncp overrides '/' or '\0' */
+					break;
+				}
+				d_ptr = (struct dirent *) ((void *)d_ptr+d_ptr->d_reclen);
+			}
+		} while(bytes_read!=0 && d_ptr->d_ino != cur->inode);
+
+		release_fd(tmp_fd);
+		if (d_ptr->d_ino != cur->inode) {   /* parent dir was fully read, child still not found */
+			iput(root);
+			iput(up);
+			if (cur != current->pwd) {
+				iput(cur);
+			}
+			kfree((unsigned int)dirent_buf);
+			return -ENOENT;
+		}
+		if (cur != current->pwd) {
+			iput(cur);
+		}
+		cur = up;
+	}
+	kfree((unsigned int)dirent_buf);
+	iput(root); /* cur == up == root */
+	/* Move the String to the start of the buffer */
+	for ( x = marker; x < size; x++) {
+		buf[x-marker]=buf[x];
+	}
+	return (unsigned int)buf;
 }

--- a/kernel/syscalls/getcwd.c
+++ b/kernel/syscalls/getcwd.c
@@ -20,6 +20,16 @@
 int sys_getcwd(char *buf, __size_t size)
 {
 	int errno;
+	struct dirent *dirent_buf;
+	struct dirent *d_ptr;
+	struct inode *cur;
+	struct inode *up;
+	struct inode *tmp_ino;
+	int tmp_fd, done;
+	int namelength, bytes_read;
+	int diff_dev;
+	__size_t marker;
+	__size_t x;
 
 #ifdef __DEBUG__
 	printk("(pid %d) sys_getcwd(0x%08x, %d)\n", current->pid, (unsigned int)buf, size);
@@ -28,30 +38,24 @@ int sys_getcwd(char *buf, __size_t size)
 	if((errno = check_user_area(VERIFY_WRITE, buf, size))) {
 		return errno;
 	}
-	/* Buffer self-allocation not supported. */
-	if (size==0 || buf==NULL) {
+	/* buffer self-allocation not supported */
+	if(size == 0 || buf == NULL) {
 		return -EINVAL;
 	}
-	/* The shortest possible path is "/". */
-	if (size<2) {
+	/* the shortest possible path is "/" */
+	if(size < 2) {
 		return -ERANGE;
 	}
-	struct dirent *dirent_buf;
-	struct dirent *d_ptr;
-	struct inode *cur = current->pwd;
-	struct inode *up = cur;
-	struct inode *tmp_ino = NULL;
-	int tmp_fd, done;
-	int namelength, bytes_read;
-	int diff_dev;
-	__size_t marker = size-2;	/* Reserve '\0' at the end. */
-	buf[size-1] = 0;
-	__size_t x;
+
+	cur = current->pwd;
+	up = cur;
+	marker = size - 2;	/* reserve '\0' at the end */
+	buf[size - 1] = 0;
 
 	if(cur == current->root) {
-		/* This case needs special handling, otherwise the loop skips over root. */
-		buf[0]='/';
-		buf[1]='\0';
+		/* this case needs special handling, otherwise the loop skips over root */
+		buf[0] = '/';
+		buf[1] = '\0';
 		return (unsigned int)buf;
 	}
 	if(!(dirent_buf = (void *)kmalloc())) {
@@ -60,7 +64,7 @@ int sys_getcwd(char *buf, __size_t size)
 
 	do {
 		if((errno = parse_namei("..", cur, &up, 0, FOLLOW_LINKS))) {
-			if (cur != current->pwd) {
+			if(cur != current->pwd) {
 				iput(cur);
 			}
 			kfree((unsigned int)dirent_buf);
@@ -68,7 +72,7 @@ int sys_getcwd(char *buf, __size_t size)
 		}
 		if((tmp_fd = get_new_fd(up)) < 0) {
 			iput(up);
-			if (cur != current->pwd) {
+			if(cur != current->pwd) {
 				iput(cur);
 			}
 			kfree((unsigned int)dirent_buf);
@@ -77,10 +81,10 @@ int sys_getcwd(char *buf, __size_t size)
 		do {
 			done = 0;
 			bytes_read = up->fsop->readdir(up, &fd_table[tmp_fd], dirent_buf, PAGE_SIZE);
-			if (bytes_read < 0) {
+			if(bytes_read < 0) {
 				release_fd(tmp_fd);
 				iput(up);
-				if (cur != current->pwd) {
+				if(cur != current->pwd) {
 					iput(cur);
 				}
 				kfree((unsigned int)dirent_buf);
@@ -88,25 +92,27 @@ int sys_getcwd(char *buf, __size_t size)
 			}
 			d_ptr = dirent_buf;
 			while((void *) d_ptr < ((void *) dirent_buf + bytes_read)) {
-				/* If the child is on the same device as the parent the d_ptr->d_ino should be correct.
-				   In this case there is no need to call a namei again. */
+				/*
+				 * If the child is on the same device as the parent the d_ptr->d_ino should be correct.
+				 * In this case there is no need to call a namei again.
+				 */
 				diff_dev = up->dev != cur->dev;
-				if (diff_dev) {
+				if(diff_dev) {
 					if((errno = parse_namei(d_ptr->d_name, up, &tmp_ino, 0, FOLLOW_LINKS))) {
-						/* Keep going if sibling dirents fail. */
+						/* keep going if sibling dirents fail */
 						break;
 					}
 				}
-				if(d_ptr->d_ino == cur->inode && !diff_dev || tmp_ino->inode == cur->inode && diff_dev) {
+				if((d_ptr->d_ino == cur->inode && !diff_dev) || (tmp_ino->inode == cur->inode && diff_dev)) {
 					if(strcmp("..", d_ptr->d_name)) {
 						namelength = strlen(d_ptr->d_name);
-						if (marker < namelength+1) {
+						if(marker < namelength + 1) {
 							release_fd(tmp_fd);
 							iput(up);
-							if (cur != current->pwd) {
+							if(cur != current->pwd) {
 								iput(cur);
 							}
-							if (diff_dev) {
+							if(diff_dev) {
 								iput(tmp_ino);
 							}
 							kfree((unsigned int)dirent_buf);
@@ -116,31 +122,31 @@ int sys_getcwd(char *buf, __size_t size)
 							buf[marker--] = d_ptr->d_name[namelength];
 						}
 						buf[marker--] = '/';
-						if (diff_dev) {
+						if(diff_dev) {
 							iput(tmp_ino);
 						}
 						done = 1;
 						break;
 					}
 				}
-				if (diff_dev) {
+				if(diff_dev) {
 					iput(tmp_ino);
 				}
 				d_ptr = (struct dirent *) ((void *)d_ptr + d_ptr->d_reclen);
 			}
-		} while(bytes_read!=0 && !done);
+		} while(bytes_read != 0 && !done);
 
 		release_fd(tmp_fd);
 		if(!done) {
-			/* Parent dir was fully read, child still not found. */
+			/* parent dir was fully read, child still not found */
 			iput(up);
-			if (cur != current->pwd) {
+			if(cur != current->pwd) {
 				iput(cur);
 			}
 			kfree((unsigned int)dirent_buf);
 			return -ENOENT;
 		}
-		if (cur != current->pwd) {
+		if(cur != current->pwd) {
 			iput(cur);
 		}
 		cur = up;
@@ -148,9 +154,9 @@ int sys_getcwd(char *buf, __size_t size)
 
 	kfree((unsigned int)dirent_buf);
 	iput(cur);
-	/* Move the String to the start of the buffer. */
-	for (x = ++marker; x < size; x++) {
-		buf[x-marker] = buf[x];
+	/* move the string to the start of the buffer */
+	for(x = ++marker; x < size; x++) {
+		buf[x - marker] = buf[x];
 	}
 	return (unsigned int)buf;
 }

--- a/kernel/syscalls/getcwd.c
+++ b/kernel/syscalls/getcwd.c
@@ -56,7 +56,7 @@ int sys_getcwd(char *buf, __size_t size)
 		/* this case needs special handling, otherwise the loop skips over root */
 		buf[0] = '/';
 		buf[1] = '\0';
-		return (unsigned int)buf;
+		return 2;
 	}
 	if(!(dirent_buf = (void *)kmalloc())) {
 		return -ENOMEM;
@@ -158,5 +158,6 @@ int sys_getcwd(char *buf, __size_t size)
 	for(x = ++marker; x < size; x++) {
 		buf[x - marker] = buf[x];
 	}
-	return (unsigned int)buf;
+	/* linux returns the length of the string, so do we */
+	return size - marker;
 }


### PR DESCRIPTION
Currently the functionality to get the current working directory in Fiwix is provided by newlib.
In Linux 2.2+ the syscall getcwd was added for this purpose.
This Implementation does increase compatibility with a few small, unmodified linux binaries and can potentially serve as a small step to port larger C Libraries.