### PR TITLE
Disable compiling with PIE option enabled by some builds of gcc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LANG = -std=c89
 CC = $(CROSS_COMPILE)gcc $(ARCH) $(CPU) $(LANG) -D__KERNEL__ #-D__DEBUG__
 LD = $(CROSS_COMPILE)ld
 
-CFLAGS = -I$(INCLUDE) -O2 -ffreestanding -Wall -Wstrict-prototypes #-Wextra -Wno-unused-parameter
+CFLAGS = -I$(INCLUDE) -O2 -fno-pie -ffreestanding -Wall -Wstrict-prototypes #-Wextra -Wno-unused-parameter
 LDFLAGS = -m elf_i386 -nostartfiles -nostdlib -nodefaultlibs -nostdinc
 
 DIRS =	kernel \


### PR DESCRIPTION
Resolves #6.