### PR TITLE
Support syscalls ftruncate64, stat64, lstat64, fstat64, and fcntl64.

### DIFF
--- a/include/fiwix/fcntl.h
+++ b/include/fiwix/fcntl.h
@@ -36,6 +36,9 @@
 #define F_GETLK		5	/* get record locking information */
 #define F_SETLK		6	/* set record locking information */
 #define F_SETLKW	7	/* same as F_SETLK; wait if blocked */
+#define F_GETLK64	F_GETLK
+#define F_SETLK64	F_SETLK
+#define F_SETLKW64	F_SETLKW
 #define F_DUPFD_CLOEXEC	1030	/* duplicate file descriptor with close-on-exec*/
 
 /* get/set process or process group ID to receive SIGURG signals */

--- a/include/fiwix/fcntl.h
+++ b/include/fiwix/fcntl.h
@@ -36,9 +36,9 @@
 #define F_GETLK		5	/* get record locking information */
 #define F_SETLK		6	/* set record locking information */
 #define F_SETLKW	7	/* same as F_SETLK; wait if blocked */
-#define F_GETLK64	F_GETLK
-#define F_SETLK64	F_SETLK
-#define F_SETLKW64	F_SETLKW
+#define F_GETLK64	12
+#define F_SETLK64	13
+#define F_SETLKW64	14
 #define F_DUPFD_CLOEXEC	1030	/* duplicate file descriptor with close-on-exec*/
 
 /* get/set process or process group ID to receive SIGURG signals */

--- a/include/fiwix/statbuf.h
+++ b/include/fiwix/statbuf.h
@@ -46,25 +46,25 @@ struct new_stat {
 };
 
 struct stat64 {
-        unsigned long long st_dev;
+        unsigned long long int st_dev;
         int __st_dev_padding;
         int __st_ino_truncated;
         unsigned int st_mode;
         unsigned int st_nlink;
         unsigned int st_uid;
         unsigned int st_gid;
-        unsigned long long st_rdev;
+        unsigned long long int st_rdev;
         int __st_rdev_padding;
-        long long st_size;
+        long long int st_size;
         int st_blksize;
-        long long st_blocks;
+        long long int st_blocks;
         int st_atime;
         int st_atime_nsec;
         int st_mtime;
         int st_mtime_nsec;
         int st_ctime;
         int st_ctime_nsec;
-        unsigned long long st_ino;
+        unsigned long long int st_ino;
 };
 
 #endif /* _FIWIX_STATBUF_H */

--- a/include/fiwix/statbuf.h
+++ b/include/fiwix/statbuf.h
@@ -48,22 +48,22 @@ struct new_stat {
 struct stat64 {
         unsigned long long st_dev;
         int __st_dev_padding;
-        long __st_ino_truncated;
-        unsigned st_mode;
+        int __st_ino_truncated;
+        unsigned int st_mode;
         unsigned int st_nlink;
-        unsigned st_uid;
-        unsigned st_gid;
+        unsigned int st_uid;
+        unsigned int st_gid;
         unsigned long long st_rdev;
         int __st_rdev_padding;
         long long st_size;
-        long st_blksize;
+        int st_blksize;
         long long st_blocks;
-        long st_atime;
-        long st_atime_nsec;
-        long st_mtime;
-        long st_mtime_nsec;
-        long st_ctime;
-        long st_ctime_nsec;
+        int st_atime;
+        int st_atime_nsec;
+        int st_mtime;
+        int st_mtime_nsec;
+        int st_ctime;
+        int st_ctime_nsec;
         unsigned long long st_ino;
 };
 

--- a/include/fiwix/statbuf.h
+++ b/include/fiwix/statbuf.h
@@ -45,4 +45,26 @@ struct new_stat {
 	unsigned int __unused5;
 };
 
+struct stat64 {
+        unsigned long long st_dev;
+        int __st_dev_padding;
+        long __st_ino_truncated;
+        unsigned st_mode;
+        unsigned int st_nlink;
+        unsigned st_uid;
+        unsigned st_gid;
+        unsigned long long st_rdev;
+        int __st_rdev_padding;
+        long long st_size;
+        long st_blksize;
+        long long st_blocks;
+        long st_atime;
+        long st_atime_nsec;
+        long st_mtime;
+        long st_mtime_nsec;
+        long st_ctime;
+        long st_ctime_nsec;
+        unsigned long long st_ino;
+};
+
 #endif /* _FIWIX_STATBUF_H */

--- a/include/fiwix/syscalls.h
+++ b/include/fiwix/syscalls.h
@@ -173,5 +173,10 @@ int sys_getcwd(char *, __size_t);
 #ifdef CONFIG_MMAP2
 int sys_mmap2(unsigned int, unsigned int, unsigned int, unsigned int, int, unsigned int);
 #endif /* CONFIG_MMAP2 */
+int sys_ftruncate64(unsigned int, __loff_t);
+int sys_stat64(const char *, struct stat64 *);
+int sys_lstat64(const char *, struct stat64 *);
+int sys_fstat64(unsigned int, struct stat64 *);
+int sys_fcntl64(unsigned int, int, unsigned long int);
 
 #endif /* _FIWIX_SYSCALLS_H */

--- a/include/fiwix/syscalls.h
+++ b/include/fiwix/syscalls.h
@@ -177,6 +177,6 @@ int sys_ftruncate64(unsigned int, __loff_t);
 int sys_stat64(const char *, struct stat64 *);
 int sys_lstat64(const char *, struct stat64 *);
 int sys_fstat64(unsigned int, struct stat64 *);
-int sys_fcntl64(unsigned int, int, unsigned long int);
+int sys_fcntl64(unsigned int, int, unsigned int);
 
 #endif /* _FIWIX_SYSCALLS_H */

--- a/kernel/syscalls.c
+++ b/kernel/syscalls.c
@@ -393,6 +393,35 @@ void *syscall_table[] = {
 #else
 	NULL,
 #endif
+	NULL,
+	sys_ftruncate64,
+	sys_stat64,			/* 195 */
+	sys_lstat64,
+	sys_fstat64,
+	NULL,
+	NULL,
+	NULL,				/* 200 */
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,				/* 205 */
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,				/* 210 */
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,				/* 215 */
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,				/* 220 */
+	sys_fcntl64,
 };
 
 static void do_bad_syscall(unsigned int num)

--- a/kernel/syscalls/fcntl64.c
+++ b/kernel/syscalls/fcntl64.c
@@ -13,7 +13,7 @@
 #include <fiwix/stdio.h>
 #include <fiwix/process.h>
 
-int sys_fcntl64(unsigned int ufd, int cmd, unsigned long int arg)
+int sys_fcntl64(unsigned int ufd, int cmd, unsigned int arg)
 {
 	int new_ufd;
 

--- a/kernel/syscalls/fcntl64.c
+++ b/kernel/syscalls/fcntl64.c
@@ -1,0 +1,63 @@
+/*
+ * fiwix/kernel/syscalls/fcntl64.c
+ *
+ * Copyright 2018-2023, Jordi Sanfeliu. All rights reserved.
+ * Copyright 2023, Richard R. Masters.
+ * Distributed under the terms of the Fiwix License.
+ */
+
+#include <fiwix/syscalls.h>
+#include <fiwix/fcntl.h>
+#include <fiwix/locks.h>
+#include <fiwix/errno.h>
+#include <fiwix/stdio.h>
+#include <fiwix/process.h>
+
+int sys_fcntl64(unsigned int ufd, int cmd, unsigned long int arg)
+{
+	int new_ufd;
+
+#ifdef __DEBUG__
+	printk("(pid %d) sys_fcntl64(%d, %d, 0x%08x)\n", current->pid, ufd, cmd, arg);
+#endif /*__DEBUG__ */
+
+	CHECK_UFD(ufd);
+	switch(cmd) {
+		case F_DUPFD_CLOEXEC:
+		case F_DUPFD:
+			if(arg >= OPEN_MAX) {
+				return -EINVAL;
+			}
+			if((new_ufd = get_new_user_fd(arg)) < 0) {
+				return new_ufd;
+			}
+			current->fd[new_ufd] = current->fd[ufd];
+                        if (cmd == F_DUPFD_CLOEXEC) {
+                            current->fd_flags[new_ufd] |= FD_CLOEXEC;
+                        }
+			fd_table[current->fd[new_ufd]].count++;
+#ifdef __DEBUG__
+			printk("\t--> returning %d\n", new_ufd);
+#endif /*__DEBUG__ */
+			return new_ufd;
+		case F_GETFD:
+			return (current->fd_flags[ufd] & FD_CLOEXEC);
+		case F_SETFD:
+			current->fd_flags[ufd] = (arg & FD_CLOEXEC);
+			break;
+		case F_GETFL:
+			return fd_table[current->fd[ufd]].flags;
+		case F_SETFL:
+			fd_table[current->fd[ufd]].flags &= ~(O_APPEND | O_NONBLOCK);
+			fd_table[current->fd[ufd]].flags |= arg & (O_APPEND | O_NONBLOCK);
+			break;
+		case F_GETLK64:
+		case F_SETLK64:
+		case F_SETLKW64:
+			printk("(pid %d) sys_fcntl64: WARNING: locks not implemented!\n", current->pid);
+			return 0;
+		default:
+			return -EINVAL;
+	}
+	return 0;
+}

--- a/kernel/syscalls/fstat64.c
+++ b/kernel/syscalls/fstat64.c
@@ -1,0 +1,45 @@
+/*
+ * fiwix/kernel/syscalls/fstat64.c
+ *
+ * Copyright 2023, Jordi Sanfeliu. All rights reserved.
+ * Copyright 2023, Richard R. Masters.
+ * Distributed under the terms of the Fiwix License.
+ */
+
+#include <fiwix/fs.h>
+#include <fiwix/syscalls.h>
+#include <fiwix/statbuf.h>
+#include <fiwix/errno.h>
+
+#ifdef __DEBUG__
+#include <fiwix/stdio.h>
+#include <fiwix/process.h>
+#endif /*__DEBUG__ */
+
+int sys_fstat64(unsigned int ufd, struct stat64 *statbuf)
+{
+	struct inode *i;
+	int errno;
+
+#ifdef __DEBUG__
+	printk("(pid %d) sys_fstat64(%d, 0x%08x) -> returning structure\n", current->pid, ufd, (unsigned int )statbuf);
+#endif /*__DEBUG__ */
+
+	CHECK_UFD(ufd);
+	if((errno = check_user_area(VERIFY_WRITE, statbuf, sizeof(struct stat64)))) {
+		return errno;
+	}
+	i = fd_table[current->fd[ufd]].inode;
+	statbuf->st_dev = i->dev;
+	statbuf->st_ino = i->inode;
+	statbuf->st_mode = i->i_mode;
+	statbuf->st_nlink = i->i_nlink;
+	statbuf->st_uid = i->i_uid;
+	statbuf->st_gid = i->i_gid;
+	statbuf->st_rdev = i->rdev;
+	statbuf->st_size = i->i_size;
+	statbuf->st_atime = i->i_atime;
+	statbuf->st_mtime = i->i_mtime;
+	statbuf->st_ctime = i->i_ctime;
+	return 0;
+}

--- a/kernel/syscalls/fstat64.c
+++ b/kernel/syscalls/fstat64.c
@@ -22,7 +22,7 @@ int sys_fstat64(unsigned int ufd, struct stat64 *statbuf)
 	int errno;
 
 #ifdef __DEBUG__
-	printk("(pid %d) sys_fstat64(%d, 0x%08x) -> returning structure\n", current->pid, ufd, (unsigned int )statbuf);
+	printk("(pid %d) sys_fstat64(%d, 0x%08x) -> returning structure\n", current->pid, ufd, (unsigned int)statbuf);
 #endif /*__DEBUG__ */
 
 	CHECK_UFD(ufd);

--- a/kernel/syscalls/ftruncate64.c
+++ b/kernel/syscalls/ftruncate64.c
@@ -1,0 +1,54 @@
+/*
+ * fiwix/kernel/syscalls/ftruncate64.c
+ *
+ * Copyright 2018-2023, Jordi Sanfeliu. All rights reserved.
+ * Copyright 2023, Richard R. Masters.
+ * Distributed under the terms of the Fiwix License.
+ */
+
+#include <fiwix/types.h>
+#include <fiwix/fs.h>
+#include <fiwix/fcntl.h>
+#include <fiwix/stat.h>
+#include <fiwix/errno.h>
+
+#ifdef __DEBUG__
+#include <fiwix/stdio.h>
+#include <fiwix/process.h>
+#endif /*__DEBUG__ */
+
+int sys_ftruncate64(unsigned int ufd, __loff_t length)
+{
+	struct inode *i;
+	int errno;
+
+#ifdef __DEBUG__
+	printk("(pid %d) sys_ftruncate64(%d, %llu)\n", current->pid, ufd, length);
+#endif /*__DEBUG__ */
+
+	CHECK_UFD(ufd);
+	i = fd_table[current->fd[ufd]].inode;
+	if((fd_table[current->fd[ufd]].flags & O_ACCMODE) == O_RDONLY) {
+		return -EINVAL;
+	}
+	if(S_ISDIR(i->i_mode)) {
+		return -EISDIR;
+	}
+	if(IS_RDONLY_FS(i)) {
+		return -EROFS;
+	}
+	if(check_permission(TO_WRITE, i) < 0) {
+		return -EPERM;
+	}
+	if((__off_t)length == i->i_size) {
+		return 0;
+	}
+
+	errno = 0;
+	if(i->fsop && i->fsop->truncate) {
+		inode_lock(i);
+		errno = i->fsop->truncate(i, (__off_t)length);
+		inode_unlock(i);
+	}
+	return errno;
+}

--- a/kernel/syscalls/lstat64.c
+++ b/kernel/syscalls/lstat64.c
@@ -23,7 +23,7 @@ int sys_lstat64(const char *filename, struct stat64 *statbuf)
 	int errno;
 
 #ifdef __DEBUG__
-	printk("(pid %d) sys_lstat64('%s', 0x%08x) -> returning structure\n", current->pid, filename, (unsigned int )statbuf);
+	printk("(pid %d) sys_lstat64('%s', 0x%08x) -> returning structure\n", current->pid, filename, (unsigned int)statbuf);
 #endif /*__DEBUG__ */
 
 	if((errno = check_user_area(VERIFY_WRITE, statbuf, sizeof(struct stat64)))) {

--- a/kernel/syscalls/lstat64.c
+++ b/kernel/syscalls/lstat64.c
@@ -1,0 +1,61 @@
+/*
+ * fiwix/kernel/syscalls/lstat64.c
+ *
+ * Copyright 2023, Jordi Sanfeliu. All rights reserved.
+ * Copyright 2023, Richard R. Masters.
+ * Distributed under the terms of the Fiwix License.
+ */
+
+#include <fiwix/fs.h>
+#include <fiwix/stat.h>
+#include <fiwix/statbuf.h>
+#include <fiwix/string.h>
+
+#ifdef __DEBUG__
+#include <fiwix/stdio.h>
+#include <fiwix/process.h>
+#endif /*__DEBUG__ */
+
+int sys_lstat64(const char *filename, struct stat64 *statbuf)
+{
+	struct inode *i;
+	char *tmp_name;
+	int errno;
+
+#ifdef __DEBUG__
+	printk("(pid %d) sys_lstat64('%s', 0x%08x) -> returning structure\n", current->pid, filename, (unsigned int )statbuf);
+#endif /*__DEBUG__ */
+
+	if((errno = check_user_area(VERIFY_WRITE, statbuf, sizeof(struct stat64)))) {
+		return errno;
+	}
+	if((errno = malloc_name(filename, &tmp_name)) < 0) {
+		return errno;
+	}
+	if((errno = namei(tmp_name, &i, NULL, !FOLLOW_LINKS))) {
+		free_name(tmp_name);
+		return errno;
+	}
+	statbuf->st_dev = i->dev;
+	statbuf->__st_dev_padding = 0;
+	statbuf->st_ino = i->inode;
+	statbuf->st_mode = i->i_mode;
+	statbuf->st_nlink = i->i_nlink;
+	statbuf->st_uid = i->i_uid;
+	statbuf->st_gid = i->i_gid;
+	statbuf->st_rdev = i->rdev;
+	statbuf->__st_rdev_padding = 0;
+	statbuf->st_size = i->i_size;
+	statbuf->st_blksize = i->sb->s_blocksize;
+	statbuf->st_blocks = i->i_blocks;
+	if(!i->i_blocks) {
+		statbuf->st_blocks = (i->i_size / i->sb->s_blocksize) * 2;
+		statbuf->st_blocks++;
+	}
+	statbuf->st_atime = i->i_atime;
+	statbuf->st_mtime = i->i_mtime;
+	statbuf->st_ctime = i->i_ctime;
+	iput(i);
+	free_name(tmp_name);
+	return 0;
+}

--- a/kernel/syscalls/stat64.c
+++ b/kernel/syscalls/stat64.c
@@ -1,0 +1,64 @@
+/*
+ * fiwix/kernel/syscalls/stat64.c
+ *
+ * Copyright 2023, Jordi Sanfeliu. All rights reserved.
+ * Copyright 2023, Richard R. Masters.
+ * Distributed under the terms of the Fiwix License.
+ */
+
+#include <fiwix/fs.h>
+#include <fiwix/stat.h>
+#include <fiwix/statbuf.h>
+#include <fiwix/string.h>
+
+#ifdef __DEBUG__
+#include <fiwix/stdio.h>
+#include <fiwix/process.h>
+#endif /*__DEBUG__ */
+
+int sys_stat64(const char *filename, struct stat64 *statbuf)
+{
+	struct inode *i;
+	char *tmp_name;
+	int errno;
+
+#ifdef __DEBUG__
+	printk("(pid %d) sys_stat64('%s', 0x%08x) -> returning structure\n", current->pid, filename, (unsigned int )statbuf);
+#endif /*__DEBUG__ */
+
+	if((errno = check_user_area(VERIFY_WRITE, statbuf, sizeof(struct stat64)))) {
+		return errno;
+	}
+	if((errno = malloc_name(filename, &tmp_name)) < 0) {
+		return errno;
+	}
+	if((errno = namei(tmp_name, &i, NULL, FOLLOW_LINKS))) {
+		free_name(tmp_name);
+		return errno;
+	}
+	statbuf->st_dev = i->dev;
+	statbuf->__st_dev_padding = 0;
+	statbuf->st_ino = i->inode;
+	statbuf->st_mode = i->i_mode;
+	statbuf->st_nlink = i->i_nlink;
+	statbuf->st_uid = i->i_uid;
+	statbuf->st_gid = i->i_gid;
+	statbuf->st_rdev = i->rdev;
+	statbuf->__st_rdev_padding = 0;
+	statbuf->st_size = i->i_size;
+	statbuf->st_blksize = i->sb->s_blocksize;
+	statbuf->st_blocks = i->i_blocks;
+	if(!i->i_blocks) {
+		statbuf->st_blocks = (i->i_size / i->sb->s_blocksize) * 2;
+		statbuf->st_blocks++;
+	}
+	statbuf->st_atime = i->i_atime;
+	statbuf->st_atime_nsec = 0;
+	statbuf->st_mtime = i->i_mtime;
+	statbuf->st_mtime_nsec = 0;
+	statbuf->st_ctime = i->i_ctime;
+	statbuf->st_ctime_nsec = 0;
+	iput(i);
+	free_name(tmp_name);
+	return 0;
+}

--- a/kernel/syscalls/stat64.c
+++ b/kernel/syscalls/stat64.c
@@ -23,7 +23,7 @@ int sys_stat64(const char *filename, struct stat64 *statbuf)
 	int errno;
 
 #ifdef __DEBUG__
-	printk("(pid %d) sys_stat64('%s', 0x%08x) -> returning structure\n", current->pid, filename, (unsigned int )statbuf);
+	printk("(pid %d) sys_stat64('%s', 0x%08x) -> returning structure\n", current->pid, filename, (unsigned int)statbuf);
 #endif /*__DEBUG__ */
 
 	if((errno = check_user_area(VERIFY_WRITE, statbuf, sizeof(struct stat64)))) {


### PR DESCRIPTION
Closes #49 