### PR TITLE
Implement stub for syscall madvise which always returns success.

### DIFF
--- a/include/fiwix/config.h
+++ b/include/fiwix/config.h
@@ -46,6 +46,7 @@
 #undef CONFIG_FS_MINIX
 #undef CONFIG_MMAP2
 #define CONFIG_NET
+#undef CONFIG_MADVISE_STUB
 
 
 /* configuration options to help debugging */

--- a/include/fiwix/syscalls.h
+++ b/include/fiwix/syscalls.h
@@ -179,6 +179,9 @@ int sys_stat64(const char *, struct stat64 *);
 int sys_lstat64(const char *, struct stat64 *);
 int sys_fstat64(unsigned int, struct stat64 *);
 int sys_chown32(const char *, unsigned int, unsigned int);
+#ifdef CONFIG_MADVISE_STUB
+int sys_madvise(void *, __size_t, int);
+#endif /* CONFIG_MADVISE_STUB */
 int sys_getdents64(unsigned int, struct dirent64 *, unsigned int);
 int sys_fcntl64(unsigned int, int, unsigned int);
 

--- a/include/fiwix/unistd.h
+++ b/include/fiwix/unistd.h
@@ -218,6 +218,8 @@
 
 #define SYS_chown32		212
 
+#define SYS_madvise		219
+
 #define SYS_getdents64		220
 #define SYS_fcntl64		221
 

--- a/kernel/syscalls.c
+++ b/kernel/syscalls.c
@@ -419,7 +419,11 @@ void *syscall_table[] = {
 	NULL,
 	NULL,
 	NULL,
-	NULL,
+#ifdef CONFIG_MADVISE_STUB
+	sys_madvise,
+#else
+	NULL,	/* sys_madvise */
+#endif /* CONFIG_MADVISE_STUB */
 	sys_getdents64,			/* 220 */
 	sys_fcntl64,
 };

--- a/kernel/syscalls/madvise.c
+++ b/kernel/syscalls/madvise.c
@@ -1,0 +1,17 @@
+/*
+ * fiwix/kernel/syscalls/madvise.c
+ *
+ * Copyright 2018-2023, Jordi Sanfeliu. All rights reserved.
+ * Copyright 2023, Richard R. Masters. All rights reserved.
+ * Distributed under the terms of the Fiwix License.
+ */
+
+#include <fiwix/process.h>
+#include <fiwix/stdio.h>
+
+#ifdef CONFIG_MADVISE_STUB
+int sys_madvise(void *addr, __size_t length, int advice)
+{
+       return 0;
+}
+#endif


### PR DESCRIPTION
Resolves #55 