### PR TITLE
Implement mapping framebuffer physical address to user space using mmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ TMPFILE := $(shell mktemp)
 ARCH = -m32
 CPU = -march=i386
 LANG = -std=c89
+#CROSS_COMPILE = x86_64-linux-musl-
 
 # CCEXE can be overridden at the command line. For example: make CCEXE="tcc"
 # To use tcc see docs/tcc.txt
@@ -22,7 +23,7 @@ CFLAGS = -I$(INCLUDE) -O2 -fno-pie -fno-common -ffreestanding -Wall -Wstrict-pro
 ifeq ($(CCEXE),gcc)
 LD = $(CROSS_COMPILE)ld
 CPP = $(CROSS_COMPILE)cpp -P -I$(INCLUDE)
-LIBGCC := $(shell dirname `$(CC) -print-libgcc-file-name`)
+LIBGCC := -L$(shell dirname `$(CC) -print-libgcc-file-name`) -lgcc
 LDFLAGS = -m elf_i386 -nostartfiles -nostdlib -nodefaultlibs -nostdinc
 endif
 
@@ -69,7 +70,7 @@ all:
 	@for n in $(DIRS) ; do (cd $$n ; $(MAKE)) || exit ; done
 ifeq ($(CCEXE),gcc)
 	$(CPP) $(CONFFLAGS) fiwix.ld > $(TMPFILE)
-	$(LD) -N -T $(TMPFILE) $(LDFLAGS) $(OBJS) -L$(LIBGCC) -lgcc -o fiwix
+	$(LD) -N -T $(TMPFILE) $(LDFLAGS) $(OBJS) $(LIBGCC) -o fiwix
 	rm -f $(TMPFILE)
 	nm fiwix | sort | gzip -9c > System.map.gz
 endif

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ TMPFILE := $(shell mktemp)
 ARCH = -m32
 CPU = -march=i386
 LANG = -std=c89
-#CROSS_COMPILE = x86_64-linux-musl-
 
 # CCEXE can be overridden at the command line. For example: make CCEXE="tcc"
 # To use tcc see docs/tcc.txt

--- a/drivers/char/fb.c
+++ b/drivers/char/fb.c
@@ -20,8 +20,8 @@
 #include <fiwix/fcntl.h>
 #include <fiwix/bios.h>
 
-#define IO_FB_XRES  2       /* TODO(ghaerr): to be removed shortly */
-#define IO_FB_YRES  3
+#define IO_FB_XRES	2	/* TODO(ghaerr): to be removed shortly */
+#define IO_FB_YRES	3
 
 static struct fs_operations fb_driver_fsop = {
 	0,
@@ -118,27 +118,27 @@ int fb_write(struct inode *i, struct fd *fd_table, const char *buffer, __size_t 
 
 int fb_mmap(struct inode *i, struct vma *vma)
 {
-    unsigned int fbaddr, addr;
+	unsigned int fbaddr, addr;
 
-    fbaddr = (unsigned int)video.address;
-    for (addr = vma->start; addr < vma->end; addr += 4096) {
-        /* map framebuffer physaddr into user space without page allocations */
-        map_page_flags(current, addr, fbaddr, PROT_READ|PROT_WRITE, PAGE_NOALLOC);
-        fbaddr += 4096;
-    }
-    return 0;
+	fbaddr = (unsigned int)video.address;
+	for (addr = vma->start; addr < vma->end; addr += 4096) {
+		/* map framebuffer physaddr into user space without page allocations */
+		map_page_flags(current, addr, fbaddr, PROT_READ|PROT_WRITE, PAGE_NOALLOC);
+		fbaddr += 4096;
+	}
+	return 0;
 }
 
 int fb_ioctl(struct inode *i, int cmd, unsigned int arg)
 {
-    switch (cmd) {
-    case IO_FB_XRES:
-        return video.fb_width;
-    case IO_FB_YRES:
-        return video.fb_height;
-    default:
-	    return -EINVAL;
-    }
+	switch (cmd) {
+		case IO_FB_XRES:
+			return video.fb_width;
+		case IO_FB_YRES:
+			return video.fb_height;
+		default:
+			return -EINVAL;
+	}
 }
 
 __loff_t fb_llseek(struct inode *i, __loff_t offset)

--- a/drivers/char/fb.c
+++ b/drivers/char/fb.c
@@ -16,7 +16,12 @@
 #include <fiwix/fb.h>
 #include <fiwix/pci.h>
 #include <fiwix/mm.h>
+#include <fiwix/mman.h>
+#include <fiwix/fcntl.h>
 #include <fiwix/bios.h>
+
+#define IO_FB_XRES  2       /* TODO(ghaerr): to be removed shortly */
+#define IO_FB_YRES  3
 
 static struct fs_operations fb_driver_fsop = {
 	0,
@@ -30,7 +35,7 @@ static struct fs_operations fb_driver_fsop = {
 	fb_llseek,
 	NULL,			/* readdir */
 	NULL,			/* readdir64 */
-	NULL,
+	fb_mmap,		/* mmap */
 	NULL,			/* select */
 
 	NULL,			/* readlink */
@@ -111,9 +116,29 @@ int fb_write(struct inode *i, struct fd *fd_table, const char *buffer, __size_t 
 	return count;
 }
 
+int fb_mmap(struct inode *i, struct vma *vma)
+{
+    unsigned int fbaddr, addr;
+
+    fbaddr = (unsigned int)video.address;
+    for (addr = vma->start; addr < vma->end; addr += 4096) {
+        /* map framebuffer physaddr into user space without page allocations */
+        map_page_flags(current, addr, fbaddr, PROT_READ|PROT_WRITE, PAGE_NOALLOC);
+        fbaddr += 4096;
+    }
+    return 0;
+}
+
 int fb_ioctl(struct inode *i, int cmd, unsigned int arg)
 {
-	return -EINVAL;
+    switch (cmd) {
+    case IO_FB_XRES:
+        return video.fb_width;
+    case IO_FB_YRES:
+        return video.fb_height;
+    default:
+	    return -EINVAL;
+    }
 }
 
 __loff_t fb_llseek(struct inode *i, __loff_t offset)

--- a/fs/devices.c
+++ b/fs/devices.c
@@ -29,6 +29,7 @@ struct fs_operations def_chr_fsop = {
 	NULL,			/* ioctl */
 	NULL,			/* llseek */
 	NULL,			/* readdir */
+	NULL,			/* readdir64 */
 	NULL,			/* mmap */
 	NULL,			/* select */
 
@@ -71,6 +72,7 @@ struct fs_operations def_blk_fsop = {
 	blk_dev_ioctl,
 	blk_dev_llseek,
 	NULL,			/* readdir */
+	NULL,			/* readdir64 */
 	NULL,			/* mmap */
 	NULL,			/* select */
 
@@ -138,7 +140,7 @@ int register_device(int type, struct device *new_d)
 	}
 
 	if(*d) {
-		if(&(*d)->minors == &new_d->minors || (&(*d)->next && &(*d)->next->minors == &new_d->minors)) {
+		if(&(*d)->minors == &new_d->minors || ((*d)->next && &(*d)->next->minors == &new_d->minors)) {
 			printk("WARNING: %s(): duplicated device major %d.\n", __FUNCTION__, new_d->major);
 			return 1;
 		}

--- a/include/fiwix/fb.h
+++ b/include/fiwix/fb.h
@@ -17,6 +17,7 @@ int fb_open(struct inode *, struct fd *);
 int fb_close(struct inode *, struct fd *);
 int fb_read(struct inode *, struct fd *, char *, __size_t);
 int fb_write(struct inode *, struct fd *, const char *, __size_t);
+int fb_mmap(struct inode *, struct vma *);
 int fb_ioctl(struct inode *, int, unsigned int);
 __loff_t fb_llseek(struct inode *, __loff_t);
 

--- a/include/fiwix/mm.h
+++ b/include/fiwix/mm.h
@@ -109,7 +109,7 @@ unsigned int get_mapped_addr(struct proc *, unsigned int);
 int clone_pages(struct proc *);
 int free_page_tables(struct proc *);
 unsigned int map_page(struct proc *, unsigned int, unsigned int, unsigned int);
-unsigned int map_page_flags(struct proc *p, unsigned int vaddr, unsigned int addr, unsigned int prot, int flags);
+unsigned int map_page_flags(struct proc *, unsigned int, unsigned int, unsigned int, int);
 int unmap_page(unsigned int);
 void mem_init(void);
 void mem_stats(void);

--- a/include/fiwix/mm.h
+++ b/include/fiwix/mm.h
@@ -109,6 +109,7 @@ unsigned int get_mapped_addr(struct proc *, unsigned int);
 int clone_pages(struct proc *);
 int free_page_tables(struct proc *);
 unsigned int map_page(struct proc *, unsigned int, unsigned int, unsigned int);
+unsigned int map_page_flags(struct proc *p, unsigned int vaddr, unsigned int addr, unsigned int prot, int flags);
 int unmap_page(unsigned int);
 void mem_init(void);
 void mem_stats(void);

--- a/include/fiwix/segments.h
+++ b/include/fiwix/segments.h
@@ -22,7 +22,7 @@
 #define PAGE_PRESENT	0x001	/* Present */
 #define PAGE_RW		0x002	/* Read/Write */
 #define PAGE_USER	0x004	/* User */
-#define PAGE_NOALLOC	0x200	/* No Page Alloced (OS Managed) */
+#define PAGE_NOALLOC	0x200	/* No Page Allocated (OS managed) */
 
 #ifndef ASM_FILE
 

--- a/include/fiwix/segments.h
+++ b/include/fiwix/segments.h
@@ -22,6 +22,7 @@
 #define PAGE_PRESENT	0x001	/* Present */
 #define PAGE_RW		0x002	/* Read/Write */
 #define PAGE_USER	0x004	/* User */
+#define PAGE_NOALLOC	0x200	/* No Page Alloced (OS Managed) */
 
 #ifndef ASM_FILE
 


### PR DESCRIPTION
Implements kernel enhancements required to compile and run [Microwindows](https://github.com/ghaerr/microwindows) on Fiwix. Discussed in https://github.com/mikaku/Fiwix/issues/78#issuecomment-1960604730.

This PR adds the following:

- Adds ability to map arbitrary addresses into user space using newly-defined `PAGE_NOALLOC` bit set in page table entry. When set, this bit specifies that the mapped address is not a `kalloc`-allocated page but instead a physical memory address outside of the page pool. This bit is one of three available bits allowed in page table entries, reserved for operating system software management.

When page table entries are created, deleted or cloned, the kernel operates slightly differently when a PTE specifies PAGE_NOALLOC, and does not call `kalloc` or `kfree` on the associated address, as the address is not an index into the page_table[] array but just a physical address outside of the otherwise managed system RAM.

- Adds `mmap` file system ops entry into the framebuffer driver and corrects `do_mmap` operations on it.
- Fixes small bugs in fs/devices.c.
- Adds temporary `ioctl` to framebuffer driver to return the framebuffer width and height. This will be removed shortly, after adding Linux framebuffer `ioctl` compatibility in the next commit.
- Adds CROSS_COMPILER= and slightly modifies LIBGCC in Makefile to allow for easier compilation of Fiwix on macOS.

The changes to Microwindows for Fiwix will be posted in the Microwindows repository and a link posted here shortly.
