### PR TITLE
Fix fbconsole scrolling bug with vi

### DIFF
--- a/drivers/video/fbcon.c
+++ b/drivers/video/fbcon.c
@@ -368,7 +368,7 @@ void fbcon_scroll_screen(struct vconsole *vc, int top, int mode)
 				}
 				if(!screen_is_off) {
 					count = video.fb_pitch * video.fb_char_height;
-					memset_l(vidmem + video.fb_vsize - count, 0, count / sizeof(unsigned int));
+					memset_l(vidmem + (vc->lines - 1) * count, 0, count / sizeof(unsigned int));
 				}
 			}
 			count = vc->columns * (vc->lines - top - 1);


### PR DESCRIPTION
Fixes incorrect framebuffer console last line displayed incorrectly when scrolling screen upward using ^D with `vi`, described in https://github.com/mikaku/Fiwix/issues/78#issuecomment-1953456433.

`vi` uses scrolling regions and the fbcon code didn't clear the last scrolled up line properly when a scrolling region was set.

During testing, another probably worse kernel problem was seen: if ^D is typed in rapid succession, say while scrolling /etc/termcap, `vi` output becomes scrambled. Not sure what this may be, but first guess is that it appears that possibly the `write` system call output (from `vi` to the console) becomes unsynchronized. This will require lots more testing to determine, but it is easily duplicated (both before and after this PR).
