### PR TITLE
Fix compiler warnings

### DIFF
--- a/drivers/block/ata.c
+++ b/drivers/block/ata.c
@@ -273,6 +273,7 @@ static int get_dma(struct ata_drv *drive)
 	return dma;
 }
 
+/*
 static int get_udma(struct ata_drv *drive)
 {
 	int udma;
@@ -296,6 +297,7 @@ static int get_udma(struct ata_drv *drive)
 	}
 	return udma;
 }
+*/
 
 static int get_ata(struct ata_drv *drive)
 {
@@ -321,7 +323,7 @@ static void show_capabilities(struct ide *ide, struct ata_drv *drive)
 	unsigned int cyl, hds, sect;
 	__loff_t size;
 	int ksize, nrsectors;
-	int udma, udma_speed[] = { 16, 25, 33, 44, 66, 100 };
+	/*int udma, udma_speed[] = { 16, 25, 33, 44, 66, 100 };*/
 
 	if(!(drive->flags & (DRIVE_IS_DISK | DRIVE_IS_CDROM))) {
 		return;
@@ -339,7 +341,7 @@ static void show_capabilities(struct ide *ide, struct ata_drv *drive)
 
 	drive->pio_mode = get_piomode(drive);
 	drive->dma_mode = get_dma(drive);
-	udma = get_udma(drive);
+	/*udma = get_udma(drive);*/
 
 	size = (__loff_t)drive->nr_sects * BPS;
 	size = size >> 10;

--- a/drivers/char/serial.c
+++ b/drivers/char/serial.c
@@ -695,7 +695,7 @@ void serial_init(void)
 		}
 
 		/* check if a serial tty will act as a system console */
-		for(n = 0, syscon = 0; n < NR_SYSCONSOLES; n++) {
+		for(n = 0, syscon = 0; n < NR_SERIAL; n++) {
 			if(is_serial(sysconsole_table[n].dev)) {
 				if((tty = get_tty(sysconsole_table[n].dev))) {
 					if(!syscon) {

--- a/drivers/char/serial.c
+++ b/drivers/char/serial.c
@@ -695,7 +695,7 @@ void serial_init(void)
 		}
 
 		/* check if a serial tty will act as a system console */
-		for(n = 0, syscon = 0; n < NR_SERIAL; n++) {
+		for(n = 0, syscon = 0; n < NR_SYSCONSOLES; n++) {
 			if(is_serial(sysconsole_table[n].dev)) {
 				if((tty = get_tty(sysconsole_table[n].dev))) {
 					if(!syscon) {

--- a/drivers/char/tty_queue.c
+++ b/drivers/char/tty_queue.c
@@ -45,6 +45,7 @@ static void put_free_cblock(struct cblock *old)
 	cblock_pool_head = old;
 }
 
+/*
 static struct cblock *insert_cblock_in_head(struct clist *q)
 {
 	struct cblock *cb;
@@ -56,7 +57,6 @@ static struct cblock *insert_cblock_in_head(struct clist *q)
 		return NULL;
 	}
 
-	/* initialize cblock */
 	cb->start_off = cb->end_off = 0;
 	memset_b(cb->data, 0, CBSIZE);
 	cb->prev = cb->next = NULL;
@@ -72,6 +72,7 @@ static struct cblock *insert_cblock_in_head(struct clist *q)
 	}
 	return cb;
 }
+*/
 
 static struct cblock *insert_cblock_in_tail(struct clist *q)
 {

--- a/fs/iso9660/inode.c
+++ b/fs/iso9660/inode.c
@@ -66,6 +66,7 @@ static int read_pathtable(struct inode *i)
 	return 0;
 }
 
+/*
 static int get_parent_dir_size(struct superblock *sb, __blk_t extent)
 {
 	int n;
@@ -85,6 +86,7 @@ static int get_parent_dir_size(struct superblock *sb, __blk_t extent)
 	printk("WARNING: %s(): unable to locate extent '%d' in path table.\n", __FUNCTION__, extent);
 	return 0;
 }
+*/
 
 int iso9660_read_inode(struct inode *i)
 {


### PR DESCRIPTION
Fixes various compiler warnings and one array index bug produced by my `x86_64-linux-musl-gcc` (version 9.2.0) compiler on macOS.

On another note, if the optimization were changed from `-O2` to `-Os` in Makefile, the kernel size is reduced by ~25k bytes. I have found that in most cases optimizing for size is also quicker than -O2. Is reducing produced kernel size important enough to change this setting? I have been running with -Os without problems? Let me know and I can push that change as well.