### PR TITLE
Remove unneeded low memory kernel virtual address mappings

### DIFF
--- a/drivers/video/bga.c
+++ b/drivers/video/bga.c
@@ -101,7 +101,7 @@ void bga_init(void)
 	video.fb_size = video.fb_width * video.fb_height * video.fb_pixelwidth;
 	video.fb_vsize = video.lines * video.fb_pitch * video.fb_char_height;
 
-	map_kaddr((unsigned int)video.address, (unsigned int)video.address + video.memsize, video.pgtbl_addr, PAGE_PRESENT | PAGE_RW);
+	map_kaddr(kpage_dir, (unsigned int)video.address, (unsigned int)video.address + video.memsize, 0, PAGE_PRESENT | PAGE_RW);
 
 	bga_write_register(VBE_DISPI_INDEX_ENABLE, VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED);
 }

--- a/drivers/video/fbcon.c
+++ b/drivers/video/fbcon.c
@@ -572,7 +572,7 @@ void fbcon_init(void)
 {
 	struct fbcon_font_desc *font_desc;
 
-	map_kaddr((unsigned int)video.address, (unsigned int)video.address + video.memsize, video.pgtbl_addr, PAGE_PRESENT | PAGE_RW);
+	map_kaddr(kpage_dir, (unsigned int)video.address, (unsigned int)video.address + video.memsize, 0, PAGE_PRESENT | PAGE_RW);
 
 	/* some parameters already set in multiboot.c */
 

--- a/drivers/video/vgacon.c
+++ b/drivers/video/vgacon.c
@@ -319,12 +319,12 @@ void vgacon_init(void)
 	bios_data = (short int *)(PAGE_OFFSET + 0x410);
 	if((*bios_data & 0x30) == 0x30) {
 		/* monochrome = 0x30 */
-		video.address = (void *)MONO_ADDR;
+		video.address = (void *)MONO_ADDR + PAGE_OFFSET;
 		video.port = MONO_6845_ADDR;
 		strcpy((char *)video.signature, "VGA monochrome 80x25");
 	} else {
 		/* color = 0x00 || 0x20 */
-		video.address = (void *)COLOR_ADDR;
+		video.address = (void *)COLOR_ADDR + PAGE_OFFSET;
 		video.port = COLOR_6845_ADDR;
 		strcpy((char *)video.signature, "VGA color 80x25");
 	}

--- a/include/fiwix/console.h
+++ b/include/fiwix/console.h
@@ -133,7 +133,6 @@ struct video_parms {
 	struct pci_device *pci_dev;
 	int flags;
 	unsigned int *address;
-	unsigned int pgtbl_addr;
 	int port;
 	int memsize;
 	unsigned char signature[32];

--- a/include/fiwix/mm.h
+++ b/include/fiwix/mm.h
@@ -102,7 +102,7 @@ void reserve_pages(unsigned int, unsigned int);
 void page_init(int);
 
 /* memory.c */
-unsigned int map_kaddr(unsigned int, unsigned int, unsigned int, int);
+unsigned int map_kaddr(unsigned int *,unsigned int, unsigned int, unsigned int, int);
 void bss_init(void);
 unsigned int setup_tmp_pgdir(unsigned int, unsigned int);
 unsigned int get_mapped_addr(struct proc *, unsigned int);

--- a/kernel/kexec.c
+++ b/kernel/kexec.c
@@ -232,7 +232,7 @@ void kexec_multiboot1(void)
 
 	map_kaddr((unsigned int *)P2V(current->tss.cr3), KEXEC_BOOT_ADDR, KEXEC_BOOT_ADDR + PAGE_SIZE, 0, PAGE_PRESENT | PAGE_RW);
 	map_kaddr((unsigned int *)P2V(idle->tss.cr3), KEXEC_BOOT_ADDR, KEXEC_BOOT_ADDR + PAGE_SIZE, 0, PAGE_PRESENT | PAGE_RW);
-    invalidate_tlb();
+	invalidate_tlb();
 
 	memcpy_b((void *)KEXEC_BOOT_ADDR, multiboot1_trampoline, PAGE_SIZE);
 
@@ -513,7 +513,7 @@ void kexec_linux(void)
 
 	map_kaddr((unsigned int *)P2V(current->tss.cr3), KEXEC_BOOT_ADDR, KEXEC_BOOT_ADDR + (PAGE_SIZE * 2), 0, PAGE_PRESENT | PAGE_RW);
 	map_kaddr((unsigned int *)P2V(idle->tss.cr3), KEXEC_BOOT_ADDR, KEXEC_BOOT_ADDR + (PAGE_SIZE * 2), 0, PAGE_PRESENT | PAGE_RW);
-    invalidate_tlb();
+	invalidate_tlb();
 
 	memcpy_b((void *)KEXEC_BOOT_ADDR, linux_trampoline, PAGE_SIZE);
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -139,7 +139,7 @@ void start_kernel(unsigned int magic, unsigned int info, unsigned int last_boot_
 	proc_slot_init(current);
 	set_tss(current);
 	load_tr(TSS);
-	current->tss.cr3 = (unsigned int)kpage_dir;
+	current->tss.cr3 = V2P((unsigned int)kpage_dir);
 	current->flags |= PF_KPROC;
 	sprintk(current->argv0, "%s", "idle");
 

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -293,7 +293,7 @@ struct proc *kernel_process(const char *name, int (*fn)(void))
 	}
 	p->tss.esp0 += PAGE_SIZE - 4;
 	p->rss++;
-	p->tss.cr3 = (unsigned int)kpage_dir;
+	p->tss.cr3 = V2P((unsigned int)kpage_dir);
 	p->tss.eip = (unsigned int)fn;
 	p->tss.esp = p->tss.esp0;
 	sprintk(p->pidstr, "%d", p->pid);

--- a/mm/bios_map.c
+++ b/mm/bios_map.c
@@ -92,8 +92,9 @@ void bios_map_reserve(unsigned int from, unsigned int to)
 {
 	if(is_addr_in_bios_map(from)) {
 		bios_map_add(from, to, MULTIBOOT_MEMORY_AVAILABLE, MULTIBOOT_MEMORY_RESERVED);
-		if (page_table_size)
+		if (page_table_size) {
 			reserve_pages(from, to);
+		}
 	}
 }
 

--- a/mm/bios_map.c
+++ b/mm/bios_map.c
@@ -92,7 +92,8 @@ void bios_map_reserve(unsigned int from, unsigned int to)
 {
 	if(is_addr_in_bios_map(from)) {
 		bios_map_add(from, to, MULTIBOOT_MEMORY_AVAILABLE, MULTIBOOT_MEMORY_RESERVED);
-		reserve_pages(from, to);
+		if (page_table_size)
+			reserve_pages(from, to);
 	}
 }
 

--- a/mm/memory.c
+++ b/mm/memory.c
@@ -54,7 +54,7 @@ unsigned int map_kaddr(unsigned int *page_dir, unsigned int from, unsigned int t
 			if (!addr) {
 				paddr = kmalloc(PAGE_SIZE);
 				if (!paddr) {
-					PANIC("%s(): no memory\n", __FUNCTION__);
+					printk("%s(): no memory\n", __FUNCTION__);
 					return 0;
 				}
 				paddr = V2P(paddr);


### PR DESCRIPTION
Previously, Fiwix mapped the memory used for the master page directory (kpage_dir) and associated page tables as an identity mapping because both kpage_dir was kept as a physical address and `map_kaddr` was written to require it.

In addition, the VGA video memory was identity mapped into kernel virtual address space.

This approach ended up creating entries in the lowest (low 4MB) entry in the master Page Directory, below PAGE_OFFSET, as the entire page directory is copied for each new process created, thus adding an undesirable memory mapping into every process. Things worked only because the ELF executable start address is usually at ~128M (0x08004800) which is above the 1M -> _last_data_addr (0x00100000+) KVA mapping used.

By only using `map_kaddr` after the final kernel Page Directory and page tables have been activated, it was rewritten to use the already-mapped PAGE_OFFSET virtual addresses instead. This saves a lot of needless extra mapping tables and also removes any entries created below PAGE_OFFSET in the master page directory, used by fork, etc. More physical memory is now available as free page frames as a result.

The VGA and FBCON drivers were also updated to use video.address + PAGE_OFFSET to eliminate the need for an identity mapping below 1M. The identity mapping for the kernel itself to 1M was also removed, as that was unneeded after `setup_tmp_pgdir` was called.

Tested using VGA and FB console on QEMU with and without initrd.