### PR TITLE
Fix major problem in do_switch routine

### DIFF
--- a/kernel/core386.S
+++ b/kernel/core386.S
@@ -294,6 +294,7 @@ BUILD_IRQ(15, irq15)
 1:
 	popfl
 	popa
+	ret
 
 .align 4
 .globl cpuid; cpuid:


### PR DESCRIPTION
While spending more time figuring out exactly how Fiwix works, I started looking closely at the `do_switch` routine, which is used by the scheduler to switch stacks and run another task.

Absolutely amazingly enough, I found that every time a task is switched *back* to run again, after restoring the flags then the register stack with `popa`, the restarted task actually falls through and executes the `cpuid` routine every time before resuming user mode execution. And it looks like this has been occurring since v1.0.0!!!!

I initially thought there must be some magic I wasn't following in the task switch. But inserting the following code will display a dot ('.) on every task switch, instead of falling through into `cpuid`:
```
diff --git a/kernel/core386.S b/kernel/core386.S
index 2577ecc..1f4a513 100644
--- a/kernel/core386.S
+++ b/kernel/core386.S
@@ -295,6 +295,16 @@ BUILD_IRQ(15, irq15)
    popfl
    popa

+   pushl   %eax
+   mov     $msg,%eax
+   pushl   %eax
+   call    printk
+   popl    %eax
+   popl    %eax
+   ret
+msg:    .byte      '.'
+        .byte      0
+
 .align 4
 .globl cpuid; cpuid:
    pushl   %ebp
```
The `cpuid` routine trashes EAX and ECX. The reason the kernel isn't crashing user programs is that the actual return from `do_switch` is back to the only place `do_switch` is normally called, the C routine `context_switch`, where EAX and ECX are essentially scratch also, as an immediate STI and RET are executed. (The `do_switch` calls in the KEXEC code appear to never return, so KEXEC did not likely see any register trashing either).

I'm not sure if a Fiwix speedup will be seen, as the normal context switch occurs at only 100HZ, even though `cpuid` was always executed with interrupts disabled.

Nothing like this one-line fix!! :)