### PR TITLE
Add Nix shell for setting up a cross compiler

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,6 @@
+with import <nixpkgs> { };
+
+pkgsCross.i686-embedded.stdenv.mkDerivation {
+  name = "env";
+}
+


### PR DESCRIPTION
This PR simply adds a Nix shell which makes compiling Fiwix in a Nix environment trivial.
