### PR TITLE
Make CONFIG_NET work with tcc

### DIFF
--- a/docs/tcc.txt
+++ b/docs/tcc.txt
@@ -37,6 +37,5 @@ These commands will build Fiwix with tcc:
 
 echo "#undef CONFIG_OFFSET64" > include/fiwix/custom_config.h
 echo "#undef CONFIG_PRINTK64" >> include/fiwix/custom_config.h
-echo "#undef CONFIG_NET" >> include/fiwix/custom_config.h
 make clean
 make CCEXE="tcc" CONFFLAGS="-DCUSTOM_CONFIG_H"

--- a/fs/procfs/data.c
+++ b/fs/procfs/data.c
@@ -415,7 +415,7 @@ int data_proc_unix(char *buffer, __pid_t pid)
 		s = u->socket;
 		fd = s->fd;
 		size += sprintk(buffer + size, "%08x: %08d %08d %08x %04d %02d % 5d %s\n",
-			&s->u.unix,
+			&s->u.unix_info,
 			u->count,	/* FIXME s->fd->count, */
 			0,
 			s->flags,

--- a/include/fiwix/net.h
+++ b/include/fiwix/net.h
@@ -44,7 +44,7 @@ struct socket {
 	struct socket *queue_head;	/* first connection in queue */
 	struct socket *next_queue;	/* next connection in queue */
 	union {
-		struct unix_info unix;
+		struct unix_info unix_info;
 	} u;
 };
 


### PR DESCRIPTION
tcc has a (in my view, stupid) "feature" where on UNIX-like systems the symbol "unix" is defined globally. This makes it unusable as a variable name.

