### PR TITLE
stop assuming the compiler is gcc if it's not tcc

### DIFF
--- a/kernel/main.c
+++ b/kernel/main.c
@@ -81,8 +81,12 @@ void start_kernel(unsigned int magic, unsigned int info, unsigned int last_boot_
 	printk("\n");
 #ifdef __TINYC__
 	printk("             (built on %s with tcc)\n", UTS_VERSION);
-#else
+#elif defined(__clang__)
+	printk("             (built on %s with Clang %s)\n", UTS_VERSION, __VERSION__);
+#elif defined(__GNUC__)
 	printk("             (built on %s with GCC %s)\n", UTS_VERSION, __VERSION__);
+#else
+	printk("             (built on %s with unknown compiler %s)\n", UTS_VERSION);
 #endif
 	printk("\n");
 	printk("DEVICE    ADDRESS         IRQ   COMMENT\n");


### PR DESCRIPTION
The previous assumption was harmless but could confuse a user. It's just better to both support clang and fall back to saying unknown compiler if we couldn't figure out which one it is.