### PR TITLE
Added support for tilde dead key

### DIFF
--- a/drivers/char/keyboard.c
+++ b/drivers/char/keyboard.c
@@ -80,7 +80,7 @@ static struct bh keyboard_bh = { 0, &irq_keyboard_bh, NULL };
 static struct interrupt irq_config_keyboard = { 0, "keyboard", &irq_keyboard, NULL };
 
 struct diacritic *diacr;
-static char *diacr_chars = "`'^ \"";
+static char *diacr_chars = "`'^~\"";
 struct diacritic grave_table[NR_DIACR] = {
 	{ 'A', '\300' },
 	{ 'E', '\310' },
@@ -116,6 +116,14 @@ struct diacritic circm_table[NR_DIACR] = {
 	{ 'i', '\356' },
 	{ 'o', '\364' },
 	{ 'u', '\373' },
+};
+struct diacritic tilde_table[NR_DIACR] = {
+	{ 'A', '\303' },
+	{ 'N', '\321' },
+	{ 'O', '\325' },
+	{ 'a', '\343' },
+	{ 'n', '\361' },
+	{ 'o', '\365' },
 };
 struct diacritic diere_table[NR_DIACR] = {
 	{ 'A', '\304' },
@@ -492,6 +500,10 @@ void irq_keyboard(int num, struct sigcontext *sc)
 					case CIRCM ^ DEAD_KEYS:
 						deadkey = 3;
 						diacr = circm_table;
+						break;
+					case TILDE ^ DEAD_KEYS:
+						deadkey = 4;
+						diacr = tilde_table;
 						break;
 					case DIERE ^ DEAD_KEYS:
 						deadkey = 5;

--- a/include/fiwix/keyboard.h
+++ b/include/fiwix/keyboard.h
@@ -87,6 +87,7 @@
 #define GRAVE		(0x00 + DEAD_KEYS)
 #define ACUTE		(0x01 + DEAD_KEYS)
 #define CIRCM		(0x02 + DEAD_KEYS)
+#define TILDE		(0x03 + DEAD_KEYS)
 #define DIERE		(0x04 + DEAD_KEYS)
 
 #define SHIFT		(0x00 + SHIFT_KEYS)


### PR DESCRIPTION
I am testing Fiwix and found it miss tilde dead key support.

As the Ã, Õ, Ñ and ã, õ, ñ were already defined in `drivers/video/font-lat9-8x8.c`, `drivers/video/font-lat9-8x14.c` and `drivers/video/font-lat9-8x16.c` and with this PR the tilde characters can be shown in 1024x768 and 800x600.

Sadly the VGA (640x480) doesn´t show Ã, Õ, ã, õ, but show Ñ and ñ, and I don't know nor why nor how to fix it.