### PR TITLE
mm, fs, kernel: size and index the pointer tables by pointer size, not sizeof(unsigned int)

### DIFF
--- a/fs/buffer.c
+++ b/fs/buffer.c
@@ -19,7 +19,7 @@
 #include <fiwix/stat.h>
 #include <fiwix/blk_queue.h>
 
-#define NR_BUF_HASH		(buffer_hash_table_size / sizeof(unsigned int))
+#define NR_BUF_HASH		(buffer_hash_table_size / sizeof(struct buffer *))
 #define BUFFER_HASH(dev, block)	(((__dev_t)(dev) ^ (__blk_t)(block)) % (NR_BUF_HASH))
 #define BUFHEAD_INDEX(size)	((size / BLKSIZE_1K) - 1)
 

--- a/fs/inode.c
+++ b/fs/inode.c
@@ -35,7 +35,7 @@
 #include <fiwix/string.h>
 
 #define INODE_HASH(dev, inode)	(((__dev_t)(dev) ^ (__ino_t)(inode)) % (NR_INO_HASH))
-#define NR_INO_HASH	(inode_hash_table_size / sizeof(unsigned int))
+#define NR_INO_HASH	(inode_hash_table_size / sizeof(struct inode *))
 
 struct inode *inode_table;		/* inode pool */
 struct inode *inode_head;		/* head of free list */

--- a/include/fiwix/syscalls.h
+++ b/include/fiwix/syscalls.h
@@ -25,7 +25,7 @@
 #include <fiwix/mman.h>
 #include <fiwix/ipc.h>
 
-#define NR_SYSCALLS	(sizeof(syscall_table) / sizeof(unsigned int))
+#define NR_SYSCALLS	(sizeof(syscall_table) / sizeof(void *))
 
 #ifdef CONFIG_SYSCALL_6TH_ARG
 int do_syscall(unsigned int, int, int, int, int, int, int, struct sigcontext);

--- a/mm/memory.c
+++ b/mm/memory.c
@@ -343,7 +343,7 @@ void mem_init(void)
 	n = (kstat.max_buffers_size * BUFFER_HASH_PERCENTAGE) / 100;
 	n = MAX(n, 10);	/* 10 buffer hashes as minimum */
 	/* buffer_hash_table is an array of pointers */
-	pages = ((n * sizeof(unsigned int)) / PAGE_SIZE) + 1;
+	pages = ((n * sizeof(struct buffer *)) / PAGE_SIZE) + 1;
 	buffer_hash_table_size = pages << PAGE_SHIFT;
 	if(!is_addr_in_bios_map(V2P(_last_data_addr) + buffer_hash_table_size)) {
 		PANIC("Not enough memory for buffer_hash_table.\n");
@@ -364,7 +364,7 @@ void mem_init(void)
 	n = (kstat.max_inodes * INODE_HASH_PERCENTAGE) / 100;
 	n = MAX(n, 10);	/* 10 inode hash buckets as minimum */
 	/* inode_hash_table is an array of pointers */
-	pages = ((n * sizeof(unsigned int)) / PAGE_SIZE) + 1;
+	pages = ((n * sizeof(struct inode *)) / PAGE_SIZE) + 1;
 	inode_hash_table_size = pages << PAGE_SHIFT;
 	if(!is_addr_in_bios_map(V2P(_last_data_addr) + inode_hash_table_size)) {
 		PANIC("Not enough memory for inode_hash_table.\n");
@@ -478,9 +478,9 @@ void mem_stats(void)
 		page_table_size / 1024,
 		kstat.max_inodes);
 	printk("hash tables: buffers=%d (%dKB), inodes=%d (%dKB), pages=%d (%dKB)\n",
-		buffer_hash_table_size / sizeof(unsigned int), buffer_hash_table_size / 1024,
-		inode_hash_table_size / sizeof(unsigned int), inode_hash_table_size / 1024,
-		page_hash_table_size / sizeof(unsigned int), page_hash_table_size / 1024);
+		buffer_hash_table_size / sizeof(struct buffer *), buffer_hash_table_size / 1024,
+		inode_hash_table_size / sizeof(struct inode *), inode_hash_table_size / 1024,
+		page_hash_table_size / sizeof(struct page *), page_hash_table_size / 1024);
 	printk("kernel: text=%dKB, data=%dKB, bss=%dKB\n\n",
 		KERNEL_TEXT_SIZE / 1024, KERNEL_DATA_SIZE / 1024, KERNEL_BSS_SIZE / 1024);
 }

--- a/mm/page.c
+++ b/mm/page.c
@@ -38,7 +38,7 @@
 
 #define PAGE_HASH(inode, offset)	(((__ino_t)(inode) ^ (__off_t)(offset)) % (NR_PAGE_HASH))
 #define NR_PAGES	(page_table_size / sizeof(struct page))
-#define NR_PAGE_HASH	(page_hash_table_size / sizeof(unsigned int))
+#define NR_PAGE_HASH	(page_hash_table_size / sizeof(struct page *))
 
 struct page *page_table;		/* page pool */
 struct page *page_head;			/* page pool head */


### PR DESCRIPTION
Fixes #113.

buffer_hash_table, inode_hash_table and page_hash_table hold pointers,
but NR_BUF_HASH / NR_INO_HASH / NR_PAGE_HASH divide the tables' byte
sizes by sizeof(unsigned int), mem_init sizes the first two the same
way, and NR_SYSCALLS counts syscall_table's function-pointer entries
with the same unit. On i386 that unit equals the pointer size, and
this patch is a no-op: every changed expression compiles to the same
constant. On an LP64 build the counts are twice the real entry count:
half the hash values index past the allocated table, and out-of-range
syscall numbers get past do_syscall's bounds check into a
function-pointer fetch beyond the end of syscall_table (mechanism and
reproducer in the issue).

The patch covers all nine sites of the idiom: the three hash
slot-count macros, NR_SYSCALLS, mem_init's two hash-table sizings, and
the three mem_stats report divisors.

Validation: the buffer.c change is the fix our riscv64 port runs; it
was root-caused from the runtime fault there, and an i386 oracle build
confirmed byte-identical output with and without it. The inode.c,
page.c, memory.c and syscalls.h changes are the same one-word
transformation and compile to the same i386 constants for the same
reason. The public ASan reproducer of the buffer.c out-of-bounds
(with an -m32 in-bounds control) is fiwix-nr-buf-hash-lp64.yml at
https://github.com/JasonGross/bootstrap-chain-bug-reproducers

Authorship note: this pull request was researched, written, and posted
by Claude (Anthropic's Fable 5 model), working on Jason Gross's behalf.